### PR TITLE
fix(auth): cookie-based token refresh — stop 15-minute forced logout (#18)

### DIFF
--- a/client/src/services/authService.test.ts
+++ b/client/src/services/authService.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { authService } from './authService';
+import api from '../utils/api';
+
+vi.mock('../utils/api', () => ({
+  default: {
+    post: vi.fn(),
+    get: vi.fn(),
+  },
+}));
+
+const mockedPost = vi.mocked(api.post);
+
+describe('authService.refreshToken (issue #18 – cookie-based refresh)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Cookie-based session: localStorage holds no tokens. Provide a complete stub.
+    const store: Record<string, string> = {};
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+      clear: () => {
+        for (const k of Object.keys(store)) delete store[k];
+      },
+    });
+  });
+
+  it('calls the refresh endpoint even when no refresh token is in localStorage (cookie auth)', async () => {
+    // Cookie-based session: localStorage holds no refresh token.
+    mockedPost.mockResolvedValueOnce({
+      data: { accessToken: 'new-access-token', expiresIn: 900 },
+    } as never);
+
+    const token = await authService.refreshToken();
+
+    // It must hit the endpoint (the httpOnly refresh cookie is sent by axios),
+    // not throw early because localStorage is empty.
+    expect(mockedPost).toHaveBeenCalledWith('/auth/refresh-token', expect.anything());
+    expect(token).toBe('new-access-token');
+  });
+
+  it('rejects (and clears tokens) only when the refresh request itself fails', async () => {
+    mockedPost.mockRejectedValueOnce(new Error('Invalid or expired refresh token'));
+
+    await expect(authService.refreshToken()).rejects.toThrow();
+    expect(mockedPost).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -210,23 +210,27 @@ export const authService: AuthServiceInterface = {
     return response.data;
   },
 
-  // Refresh access token using refresh token
+  // Refresh access token using the refresh token.
+  // Auth is cookie-based: the httpOnly refreshToken cookie is sent automatically
+  // (api has withCredentials). A localStorage refresh token is only present for
+  // legacy sessions, so we must NOT require one here — doing so would abort every
+  // cookie-based refresh and force-log-out users when the access cookie expires.
   refreshToken: async (): Promise<string> => {
-    const refreshToken = authService.getRefreshToken();
-    if (!refreshToken) {
-      throw new Error('No refresh token available');
-    }
+    const storedRefreshToken = authService.getRefreshToken();
 
     try {
-      const response = await api.post<RefreshTokenResponse>('/auth/refresh-token', {
-        refreshToken,
-      });
+      const response = await api.post<RefreshTokenResponse>(
+        '/auth/refresh-token',
+        // Send the legacy token in the body when we have one; the server also
+        // accepts the refresh token from the httpOnly cookie.
+        storedRefreshToken ? { refreshToken: storedRefreshToken } : {}
+      );
 
       if (response.data.accessToken) {
-        // Update access token using setTokens to encrypt it
-        const currentRefreshToken = authService.getRefreshToken();
-        if (currentRefreshToken) {
-          authService.setTokens(response.data.accessToken, currentRefreshToken);
+        // The backend sets the new access token as an httpOnly cookie. For legacy
+        // localStorage sessions, keep the encrypted copy in sync as well.
+        if (storedRefreshToken) {
+          authService.setTokens(response.data.accessToken, storedRefreshToken);
         }
         return response.data.accessToken;
       }


### PR DESCRIPTION
Closes #18.

## Problem
Auth was migrated to httpOnly cookies, but `authService.refreshToken()` still required a refresh token in localStorage and threw `No refresh token available` **before ever calling the endpoint**. So when the 15-minute access cookie expired, the axios interceptor's refresh attempt threw, tokens were cleared, and the user was hard-redirected to `/login` — every session, every 15 minutes, losing in-progress work, despite holding a valid 7-day refresh cookie.

## Fix
Attempt the refresh unconditionally. The httpOnly refresh cookie is sent automatically (`withCredentials`), and the legacy localStorage token is still passed in the body when present. Redirect to login only when the refresh request itself fails.

## Tests
Adds `authService.test.ts` regression tests: refresh is attempted with no localStorage token (cookie path), and only rejects/clears when the request fails. Full typecheck + client/server unit suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)