### PR TITLE
fix(auth): stop logging password material on login (#28)

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -138,13 +138,6 @@ const login = async (req, res) => {
 
     const { email, password } = req.body;
 
-    console.log('🔍 Login request body:', {
-      email,
-      passwordLength: password?.length,
-      passwordFirstChar: password?.[0],
-      passwordLastChar: password?.[password.length - 1],
-    });
-
     // Find user
     // Use generic error message to prevent user enumeration
     const user = await User.findOne({ email });
@@ -160,12 +153,9 @@ const login = async (req, res) => {
     }
 
     // Check password
-    console.log('🔍 Login attempt for:', email, '(role:', user.role, ')');
     const isMatch = await user.comparePassword(password);
-    console.log('🔍 Password match result:', isMatch);
 
     if (!isMatch) {
-      console.log('❌ Password mismatch for:', email);
       logger.authAttempt(false, {
         userId: user._id,
         email,
@@ -176,8 +166,6 @@ const login = async (req, res) => {
       // Use generic error message to prevent user enumeration
       return res.status(401).json({ message: 'Invalid credentials' });
     }
-
-    console.log('✅ Password matched for:', email);
 
     // Check if email is verified
     // Skip verification check for pre-seeded test users (they have isEmailVerified: true)


### PR DESCRIPTION
Closes #28.

Part of a stacked per-issue PR series for the bug/deployment sweep. **Based on `fix/18-cookie-token-refresh`** — review/merge the stack in order.

See the commit for the full rationale. Reconstructed tree for the whole stack is byte-identical to the verified working branch; typecheck + unit suites pass.