### PR TITLE
fix(auth): enforce account suspension and deactivation (#19)

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -167,6 +167,33 @@ const login = async (req, res) => {
       return res.status(401).json({ message: 'Invalid credentials' });
     }
 
+    // Block suspended or deactivated accounts from obtaining a new session.
+    if (user.isActive === false) {
+      logger.authAttempt(false, {
+        userId: user._id,
+        email,
+        ip: req.ip,
+        userAgent: req.get('User-Agent'),
+        reason: 'account_deactivated',
+      });
+      return res.status(403).json({ message: 'Your account has been deactivated.' });
+    }
+
+    if (user.isCurrentlySuspended()) {
+      logger.authAttempt(false, {
+        userId: user._id,
+        email,
+        ip: req.ip,
+        userAgent: req.get('User-Agent'),
+        reason: 'account_suspended',
+      });
+      return res.status(403).json({
+        message: user.suspensionReason
+          ? `Your account has been suspended: ${user.suspensionReason}`
+          : 'Your account has been suspended.',
+      });
+    }
+
     // Check if email is verified
     // Skip verification check for pre-seeded test users (they have isEmailVerified: true)
     if (!user.isEmailVerified) {

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -39,6 +39,37 @@ const auth = async (req: Request, res: Response, next: NextFunction): Promise<vo
       return;
     }
 
+    // Enforce account suspension/deactivation on every authenticated request,
+    // not just admin routes — otherwise a suspended user keeps full access until
+    // their session expires.
+    const account = sessionData.user as {
+      isActive?: boolean;
+      isSuspended?: boolean;
+      suspendedUntil?: Date | string;
+      isCurrentlySuspended?: () => boolean;
+    };
+    const suspended =
+      typeof account.isCurrentlySuspended === 'function'
+        ? account.isCurrentlySuspended()
+        : Boolean(
+            account.isSuspended &&
+            (!account.suspendedUntil || new Date() < new Date(account.suspendedUntil))
+          );
+
+    if (account.isActive === false || suspended) {
+      logger.securityEvent('SUSPENDED_ACCOUNT_ACCESS', {
+        ip: req.ip,
+        userAgent: req.get('User-Agent'),
+        path: req.path,
+      });
+      res.status(403).json({
+        message: suspended
+          ? 'Your account has been suspended.'
+          : 'Your account has been deactivated.',
+      });
+      return;
+    }
+
     req.token = token;
     req.user = sessionData.user;
     req.sessionId = sessionData.sessionId;


### PR DESCRIPTION
Closes #19.

Part of a stacked per-issue PR series for the bug/deployment sweep. **Based on `fix/28-stop-password-logging`** — review/merge the stack in order.

See the commit for the full rationale. Reconstructed tree for the whole stack is byte-identical to the verified working branch; typecheck + unit suites pass.