### PR TITLE
fix(messaging): send recipientId to match the server (#21)

### DIFF
--- a/client/src/components/messaging/MessageForm.tsx
+++ b/client/src/components/messaging/MessageForm.tsx
@@ -117,7 +117,7 @@ const MessageForm: React.FC<MessageFormProps> = ({
     }
 
     sendMessageMutation.mutate({
-      recipient: formData.recipientId,
+      recipientId: formData.recipientId,
       subject: formData.subject.trim(),
       content: formData.content.trim(),
     });

--- a/client/src/pages/MemberSearch.tsx
+++ b/client/src/pages/MemberSearch.tsx
@@ -106,7 +106,7 @@ const MemberSearch: React.FC = () => {
 
     sendMessageMutation.mutate(
       {
-        recipient: selectedUser._id,
+        recipientId: selectedUser._id,
         subject: messageData.subject,
         content: messageData.content,
       },

--- a/client/src/services/usersService.ts
+++ b/client/src/services/usersService.ts
@@ -16,7 +16,8 @@ export interface UserSearchParams {
  * Message data for sending a new message
  */
 export interface SendMessageData {
-  recipient: string;
+  // Must match the server's message validator/controller, which read `recipientId`.
+  recipientId: string;
   subject: string;
   content: string;
 }


### PR DESCRIPTION
Closes #21.

Part of a stacked per-issue PR series for the bug/deployment sweep. **Based on `fix/20-multer-upload`** — review/merge the stack in order.

See the commit for the full rationale. Reconstructed tree for the whole stack is byte-identical to the verified working branch; typecheck + unit suites pass.