### PR TITLE
fix(users): map search term to the server's query param (#22)

### DIFF
--- a/client/src/services/usersService.ts
+++ b/client/src/services/usersService.ts
@@ -123,7 +123,8 @@ export const usersService: UsersServiceInterface = {
     Object.keys(searchParams).forEach((key) => {
       const value = searchParams[key];
       if (value) {
-        params.append(key, value);
+        // The server reads the free-text term as `query`, not `search`.
+        params.append(key === 'search' ? 'query' : key, value);
       }
     });
 


### PR DESCRIPTION
Closes #22.

Part of a stacked per-issue PR series for the bug/deployment sweep. **Based on `fix/21-message-recipientid`** — review/merge the stack in order.

See the commit for the full rationale. Reconstructed tree for the whole stack is byte-identical to the verified working branch; typecheck + unit suites pass.