### PR TITLE
fix(admin): fix user-details projects query (#24)

### DIFF
--- a/client/src/services/usersService.ts
+++ b/client/src/services/usersService.ts
@@ -123,7 +123,8 @@ export const usersService: UsersServiceInterface = {
     Object.keys(searchParams).forEach((key) => {
       const value = searchParams[key];
       if (value) {
-        params.append(key, value);
+        // The server reads the free-text term as `query`, not `search`.
+        params.append(key === 'search' ? 'query' : key, value);
       }
     });
 

--- a/server/controllers/adminController.js
+++ b/server/controllers/adminController.js
@@ -221,9 +221,11 @@ const getUserDetails = async (req, res) => {
       .select('deviceInfo location lastActivity createdAt')
       .sort({ lastActivity: -1 });
 
-    // Get user's projects
+    // Get user's projects (owner or accepted/pending collaborator).
+    // The schema uses `owner` (not `createdBy`) and `collaborators` is an array of
+    // subdocuments keyed by `userId`, so match on `collaborators.userId`.
     const projects = await Project.find({
-      $or: [{ createdBy: userId }, { collaborators: userId }],
+      $or: [{ owner: userId }, { 'collaborators.userId': userId }],
     })
       .select('title status createdAt')
       .sort({ createdAt: -1 })


### PR DESCRIPTION
Closes #24.

Part of a stacked per-issue PR series for the bug/deployment sweep. **Based on `fix/22-user-search-query`** — review/merge the stack in order.

See the commit for the full rationale. Reconstructed tree for the whole stack is byte-identical to the verified working branch; typecheck + unit suites pass.