### PR TITLE
fix(projects): wire up project deletion (#25)

### DIFF
--- a/client/src/components/projects/ProjectDetail.tsx
+++ b/client/src/components/projects/ProjectDetail.tsx
@@ -39,6 +39,7 @@ import {
   useProject,
   useRequestCollaboration,
   useHandleCollaborationRequest,
+  useDeleteProject,
 } from '../../hooks/projects';
 import { useComments, useCreateComment } from '../../hooks/comments';
 import type {
@@ -111,6 +112,7 @@ const ProjectDetail: React.FC = () => {
   const createCommentMutation = useCreateComment();
   const requestCollaborationMutation = useRequestCollaboration();
   const handleCollaborationMutation = useHandleCollaborationRequest();
+  const deleteProjectMutation = useDeleteProject();
 
   // Local state
   const [comment, setComment] = useState<string>('');
@@ -168,10 +170,17 @@ const ProjectDetail: React.FC = () => {
   };
 
   const confirmDelete = (): void => {
-    // TODO: Implement project deletion
-    // dispatch(deleteProject(projectId));
-    setShowDeleteDialog(false);
-    navigate('/projects');
+    if (!projectId) return;
+    deleteProjectMutation.mutate(projectId, {
+      onSuccess: () => {
+        setShowDeleteDialog(false);
+        navigate('/projects');
+      },
+      onError: () => {
+        // Keep the dialog open so the user sees it failed and can retry.
+        setShowDeleteDialog(false);
+      },
+    });
   };
 
   const handleCollaborate = async (): Promise<void> => {

--- a/client/src/components/projects/ProjectDetail.tsx
+++ b/client/src/components/projects/ProjectDetail.tsx
@@ -177,8 +177,7 @@ const ProjectDetail: React.FC = () => {
         navigate('/projects');
       },
       onError: () => {
-        // Keep the dialog open so the user sees it failed and can retry.
-        setShowDeleteDialog(false);
+        // Keep the dialog open so the user can see it failed and retry.
       },
     });
   };


### PR DESCRIPTION
Closes #25. (Re-created against main after the original #59 was auto-closed when its stacked base branch was deleted mid-merge.) Includes the review fix to keep the delete dialog open on error.