### PR TITLE
refactor(client): remove unnecessary useEffect anti-patterns

### DIFF
--- a/client/src/components/admin/UserManagement.tsx
+++ b/client/src/components/admin/UserManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, ChangeEvent } from 'react';
+import React, { useState, ChangeEvent } from 'react';
 import {
   Box,
   Paper,
@@ -165,15 +165,6 @@ interface EditRoleDialogProps {
 const EditRoleDialog: React.FC<EditRoleDialogProps> = ({ open, user, onClose, onSave }) => {
   const [role, setRole] = useState<UserRole>(user?.role || 'user');
   const [loading, setLoading] = useState(false);
-
-  // The dialog stays mounted across selections, so the initial useState value is
-  // stale for every user after the first. Re-sync the role to the selected user
-  // whenever the dialog opens, otherwise saving can silently demote them.
-  useEffect(() => {
-    if (open && user) {
-      setRole(user.role);
-    }
-  }, [open, user]);
 
   const handleSave = async (): Promise<void> => {
     if (!user) return;
@@ -492,9 +483,12 @@ const UserManagement: React.FC = () => {
 
       {/* Dialogs */}
       <EditRoleDialog
+        key={editDialog.user?._id}
         open={editDialog.open}
         user={editDialog.user}
-        onClose={() => setEditDialog({ open: false, user: null })}
+        // Keep the user set on close so the key stays stable and the dialog plays its
+        // exit animation; it's replaced when a different user's dialog is opened.
+        onClose={() => setEditDialog((prev) => ({ ...prev, open: false }))}
         onSave={handleUpdateRole}
       />
 

--- a/client/src/components/auth/Login.tsx
+++ b/client/src/components/auth/Login.tsx
@@ -46,13 +46,6 @@ const Login: React.FC = () => {
     }
   }, [isAuthenticated, navigate]);
 
-  // Clear needs verification when component unmounts
-  useEffect(() => {
-    return () => {
-      setNeedsVerification(false);
-    };
-  }, []);
-
   const validateForm = (): boolean => {
     const errors: LoginFormErrors = {};
     if (!formData.email) {

--- a/client/src/components/auth/Register.tsx
+++ b/client/src/components/auth/Register.tsx
@@ -64,13 +64,6 @@ const Register: React.FC = () => {
     }
   }, [isAuthenticated, navigate]);
 
-  // Clear registration success message when component unmounts
-  useEffect(() => {
-    return () => {
-      setRegistrationSuccess(false);
-    };
-  }, []);
-
   const validateForm = (): boolean => {
     const errors: RegisterFormErrors = {};
     if (!formData.username) {

--- a/client/src/components/auth/ResetPassword.tsx
+++ b/client/src/components/auth/ResetPassword.tsx
@@ -32,8 +32,11 @@ const ResetPassword: React.FC = () => {
   const [confirmPassword, setConfirmPassword] = useState<string>('');
   const [passwordError, setPasswordError] = useState<string>('');
   const [confirmPasswordError, setConfirmPasswordError] = useState<string>('');
-  const [token, setToken] = useState<string>('');
   const [passwordResetSuccess, setPasswordResetSuccess] = useState<boolean>(false);
+
+  // Token is available during render from the URL — derive it instead of
+  // mirroring it into state via an effect.
+  const token = searchParams.get('token') ?? '';
 
   // Query to verify the password reset token
   const {
@@ -42,15 +45,13 @@ const ResetPassword: React.FC = () => {
     error: tokenError,
   } = usePasswordResetTokenQuery(token);
 
+  // No token in URL — redirect to forgot password. Isolated in a tiny effect
+  // gated on the derived value.
   useEffect(() => {
-    const tokenFromUrl = searchParams.get('token');
-    if (tokenFromUrl) {
-      setToken(tokenFromUrl);
-    } else {
-      // No token in URL, redirect to forgot password
+    if (!token) {
       navigate('/forgot-password');
     }
-  }, [searchParams, navigate]);
+  }, [token, navigate]);
 
   const validateForm = (): boolean => {
     let isValid = true;

--- a/client/src/components/projects/ProjectForm.tsx
+++ b/client/src/components/projects/ProjectForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, type ChangeEvent, type FormEvent } from 'react';
+import React, { useState, type ChangeEvent, type FormEvent } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   Container,
@@ -81,44 +81,71 @@ interface FormErrors {
   [key: string]: string | undefined;
 }
 
-const ProjectForm: React.FC = () => {
+// Maps a fetched project (or undefined, for create mode) into initial form state.
+const mapProjectToFormData = (initialProject: ProjectApiResponse | undefined): FormData => {
+  if (!initialProject) {
+    return {
+      title: '',
+      description: '',
+      technologies: [],
+      requiredSkills: [],
+      tags: [],
+      githubUrl: '',
+      liveUrl: '',
+      resources: [{ name: '', url: '' }],
+      status: 'ideation',
+      incentives: {
+        enabled: false,
+        type: 'recognition',
+        description: '',
+        amount: 0,
+        currency: 'USD',
+        equityPercentage: 0,
+        customReward: '',
+      },
+    };
+  }
+
+  return {
+    title: initialProject.title || '',
+    description: initialProject.description || '',
+    technologies: initialProject.technologies || [],
+    requiredSkills: initialProject.requiredSkills || [],
+    tags: initialProject.tags || [],
+    githubUrl: initialProject.githubUrl || '',
+    liveUrl: initialProject.liveUrl || '',
+    resources: initialProject.resources?.length
+      ? initialProject.resources.map((r) => ({ name: r.name, url: r.url }))
+      : [{ name: '', url: '' }],
+    status: initialProject.status || 'ideation',
+    incentives: {
+      enabled: initialProject.incentives?.enabled ?? false,
+      type: initialProject.incentives?.type ?? 'recognition',
+      description: initialProject.incentives?.description ?? '',
+      amount: initialProject.incentives?.amount ?? 0,
+      currency: initialProject.incentives?.currency ?? 'USD',
+      equityPercentage: initialProject.incentives?.equityPercentage ?? 0,
+      customReward: initialProject.incentives?.customReward ?? '',
+    },
+  };
+};
+
+interface ProjectFormFieldsProps {
+  initialProject: ProjectApiResponse | undefined;
+  projectId: string | undefined;
+}
+
+// Owns the editable form state. Seeded once from initialProject via a useState
+// initializer; the parent remounts this via `key` when the project identity changes,
+// so a background refetch of the same project never clobbers in-progress edits.
+const ProjectFormFields: React.FC<ProjectFormFieldsProps> = ({ initialProject, projectId }) => {
   const navigate = useNavigate();
-  const { projectId } = useParams<{ projectId: string }>();
-
-  // Auth state
-  const { isAuthenticated } = useAuth();
-
-  // Project data for editing - useProject handles enabled internally based on projectId
-  const {
-    data: currentProject,
-    isLoading: loading,
-    error: projectError,
-  } = useProject(projectId) as UseProjectResult;
 
   // Mutations
   const createProjectMutation = useCreateProject();
   const updateProjectMutation = useUpdateProject();
 
-  const [formData, setFormData] = useState<FormData>({
-    title: '',
-    description: '',
-    technologies: [],
-    requiredSkills: [],
-    tags: [],
-    githubUrl: '',
-    liveUrl: '',
-    resources: [{ name: '', url: '' }],
-    status: 'ideation',
-    incentives: {
-      enabled: false,
-      type: 'recognition',
-      description: '',
-      amount: 0,
-      currency: 'USD',
-      equityPercentage: 0,
-      customReward: '',
-    },
-  });
+  const [formData, setFormData] = useState<FormData>(() => mapProjectToFormData(initialProject));
 
   const [formErrors, setFormErrors] = useState<FormErrors>({});
 
@@ -174,37 +201,6 @@ const ProjectForm: React.FC = () => {
     'Git',
     'Docker',
   ];
-
-  // TanStack Query will automatically fetch the project when projectId exists
-
-  useEffect(() => {
-    if (currentProject && projectId) {
-      console.log('📝 Setting form data for editing:', currentProject);
-      console.log('📋 Current requiredSkills:', currentProject.requiredSkills);
-      setFormData({
-        title: currentProject.title || '',
-        description: currentProject.description || '',
-        technologies: currentProject.technologies || [],
-        requiredSkills: currentProject.requiredSkills || [],
-        tags: currentProject.tags || [],
-        githubUrl: currentProject.githubUrl || '',
-        liveUrl: currentProject.liveUrl || '',
-        resources: currentProject.resources?.length
-          ? currentProject.resources.map((r) => ({ name: r.name, url: r.url }))
-          : [{ name: '', url: '' }],
-        status: currentProject.status || 'ideation',
-        incentives: {
-          enabled: currentProject.incentives?.enabled ?? false,
-          type: currentProject.incentives?.type ?? 'recognition',
-          description: currentProject.incentives?.description ?? '',
-          amount: currentProject.incentives?.amount ?? 0,
-          currency: currentProject.incentives?.currency ?? 'USD',
-          equityPercentage: currentProject.incentives?.equityPercentage ?? 0,
-          customReward: currentProject.incentives?.customReward ?? '',
-        },
-      });
-    }
-  }, [currentProject, projectId]);
 
   const validateForm = (): boolean => {
     const errors: FormErrors = {};
@@ -353,62 +349,6 @@ const ProjectForm: React.FC = () => {
       alert('Please fix the form errors before submitting.');
     }
   };
-
-  // Check authentication
-  if (!isAuthenticated) {
-    return (
-      <Container maxWidth="md" sx={{ mt: 4, mb: 4 }}>
-        <Alert severity="warning" sx={{ mb: 3 }}>
-          <Typography variant="h6" gutterBottom>
-            Authentication Required
-          </Typography>
-          You must be logged in to create or edit projects.
-        </Alert>
-        <Button variant="contained" onClick={() => navigate('/login')}>
-          Go to Login
-        </Button>
-      </Container>
-    );
-  }
-
-  // Loading state for editing
-  if (projectId && loading) {
-    return (
-      <Container maxWidth="md" sx={{ mt: 4, mb: 4 }}>
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            minHeight: '300px',
-          }}
-        >
-          <CircularProgress />
-          <Typography variant="h6" sx={{ ml: 2 }}>
-            Loading project data...
-          </Typography>
-        </Box>
-      </Container>
-    );
-  }
-
-  // Error state for editing
-  if (projectId && projectError) {
-    const errorObj = projectError as Error & { response?: { data?: { message?: string } } };
-    return (
-      <Container maxWidth="md" sx={{ mt: 4, mb: 4 }}>
-        <Alert severity="error" sx={{ mb: 3 }}>
-          <Typography variant="h6" gutterBottom>
-            Error Loading Project
-          </Typography>
-          {errorObj?.response?.data?.message || errorObj?.message || 'Failed to load project data'}
-        </Alert>
-        <Button variant="contained" onClick={() => navigate('/projects')}>
-          Back to Projects
-        </Button>
-      </Container>
-    );
-  }
 
   return (
     <Container maxWidth="md" sx={{ mt: 4, mb: 4 }}>
@@ -669,6 +609,89 @@ const ProjectForm: React.FC = () => {
         </form>
       </Paper>
     </Container>
+  );
+};
+
+const ProjectForm: React.FC = () => {
+  const navigate = useNavigate();
+  const { projectId } = useParams<{ projectId: string }>();
+
+  // Auth state
+  const { isAuthenticated } = useAuth();
+
+  // Project data for editing - useProject handles enabled internally based on projectId.
+  // TanStack Query will automatically fetch the project when projectId exists.
+  const {
+    data: currentProject,
+    isLoading: loading,
+    error: projectError,
+  } = useProject(projectId) as UseProjectResult;
+
+  // Check authentication
+  if (!isAuthenticated) {
+    return (
+      <Container maxWidth="md" sx={{ mt: 4, mb: 4 }}>
+        <Alert severity="warning" sx={{ mb: 3 }}>
+          <Typography variant="h6" gutterBottom>
+            Authentication Required
+          </Typography>
+          You must be logged in to create or edit projects.
+        </Alert>
+        <Button variant="contained" onClick={() => navigate('/login')}>
+          Go to Login
+        </Button>
+      </Container>
+    );
+  }
+
+  // Loading state for editing
+  if (projectId && loading) {
+    return (
+      <Container maxWidth="md" sx={{ mt: 4, mb: 4 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            minHeight: '300px',
+          }}
+        >
+          <CircularProgress />
+          <Typography variant="h6" sx={{ ml: 2 }}>
+            Loading project data...
+          </Typography>
+        </Box>
+      </Container>
+    );
+  }
+
+  // Error state for editing
+  if (projectId && projectError) {
+    const errorObj = projectError as Error & { response?: { data?: { message?: string } } };
+    return (
+      <Container maxWidth="md" sx={{ mt: 4, mb: 4 }}>
+        <Alert severity="error" sx={{ mb: 3 }}>
+          <Typography variant="h6" gutterBottom>
+            Error Loading Project
+          </Typography>
+          {errorObj?.response?.data?.message || errorObj?.message || 'Failed to load project data'}
+        </Alert>
+        <Button variant="contained" onClick={() => navigate('/projects')}>
+          Back to Projects
+        </Button>
+      </Container>
+    );
+  }
+
+  // Data is present (edit mode gates on loading above) or absent (create mode).
+  // The `key` remounts the form body when the project identity changes, seeding
+  // fresh local state from initialProject without an effect.
+  return (
+    <ProjectFormFields
+      key={projectId ?? 'new'}
+      initialProject={currentProject}
+      projectId={projectId}
+    />
   );
 };
 

--- a/client/src/pages/EmailVerification.tsx
+++ b/client/src/pages/EmailVerification.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import {
   Container,
@@ -24,68 +24,55 @@ const EmailVerification: React.FC = () => {
   const navigate = useNavigate();
   const [status, setStatus] = useState<VerificationStatus>('verifying');
   const [message, setMessage] = useState('');
-  const hasVerified = useRef(false);
-  const verificationPromise = useRef<Promise<VerifyResponse> | null>(null);
 
   // Get token from either URL params or query string
   const token = paramToken || searchParams.get('token');
 
+  // The verify endpoint consumes the single-use token on first success. Cache the
+  // in-flight request per token in a ref so React StrictMode's double-invoke (or any
+  // re-mount for the same token) issues the request exactly ONCE and both invocations
+  // subscribe to the same promise. The `ignore` flag then guards only stale state
+  // writes after unmount / token change.
+  const requestRef = useRef<{ token: string; promise: Promise<VerifyResponse> } | null>(null);
+
   useEffect(() => {
-    const verifyEmail = async (): Promise<VerifyResponse | undefined> => {
-      if (!token) {
-        setStatus('error');
-        setMessage('No verification token provided');
-        return;
-      }
+    if (!token) {
+      setStatus('error');
+      setMessage('No verification token provided');
+      return;
+    }
 
-      // If verification is already in progress, wait for it
-      if (verificationPromise.current) {
-        console.log('Verification already in progress, waiting...');
-        return verificationPromise.current;
-      }
+    let ignore = false;
 
-      // If already verified, don't verify again
-      if (hasVerified.current) {
-        console.log('Already verified, skipping...');
-        return;
-      }
+    if (!requestRef.current || requestRef.current.token !== token) {
+      requestRef.current = {
+        token,
+        promise: api.get<VerifyResponse>(`/auth/verify-email/${token}`).then((res) => res.data),
+      };
+    }
 
-      console.log('Starting verification for token:', token);
-      hasVerified.current = true;
-
-      // Create and store the verification promise
-      verificationPromise.current = (async (): Promise<VerifyResponse> => {
-        try {
-          console.log('Making verification request...');
-          const response = await api.get<VerifyResponse>(`/auth/verify-email/${token}`);
-          console.log('Verification success:', response.data);
+    requestRef.current.promise.then(
+      (data) => {
+        if (!ignore) {
           setStatus('success');
-          setMessage(response.data.message);
-          return response.data;
-        } catch (error) {
-          console.error('=== VERIFICATION ERROR DEBUG ===');
-          console.error('Full error object:', error);
-          const axiosError = error as {
-            response?: { data?: { message?: string } };
-            message?: string;
-          };
-          console.error('Error message:', axiosError.message);
-          console.error('Error response exists?', !!axiosError.response);
-          if (axiosError.response) {
-            console.error('Error data:', axiosError.response.data);
-          }
-          console.error('Token being used:', token);
-          console.error('=== END DEBUG ===');
+          setMessage(data.message);
+        }
+      },
+      (error) => {
+        const axiosError = error as {
+          response?: { data?: { message?: string } };
+          message?: string;
+        };
+        if (!ignore) {
           setStatus('error');
           setMessage(axiosError.response?.data?.message || 'Verification failed');
-          throw error;
         }
-      })();
+      }
+    );
 
-      return verificationPromise.current;
+    return () => {
+      ignore = true;
     };
-
-    verifyEmail();
   }, [token]);
 
   const getContent = (): React.ReactNode => {

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, ChangeEvent, FormEvent, KeyboardEvent } from 'react';
+import React, { useState, useRef, ChangeEvent, FormEvent, KeyboardEvent } from 'react';
 import {
   Container,
   Typography,
@@ -45,63 +45,39 @@ interface UserWithId extends Omit<User, 'id'> {
   profileImage?: string;
 }
 
-const Profile: React.FC = () => {
-  // Auth and profile data
-  const { isAuthenticated } = useAuth();
-  const { data: profile, isLoading: profileLoading, error: profileError } = useMyProfile();
+interface ProfileFormProps {
+  profile: UserWithId | undefined;
+  profileError: unknown;
+}
+
+const ProfileForm: React.FC<ProfileFormProps> = ({ profile, profileError }) => {
   const updateProfileMutation = useUpdateProfile();
   const uploadAvatarMutation = useUploadAvatar();
   const deleteAvatarMutation = useDeleteAvatar();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const [formData, setFormData] = useState<ProfileFormData>({
-    firstName: '',
-    lastName: '',
-    bio: '',
-    skills: [],
-    experience: 'beginner',
-    location: '',
-    timezone: '',
-    availability: 'flexible',
-    portfolioLinks: [],
+  const [formData, setFormData] = useState<ProfileFormData>(() => ({
+    firstName: profile?.firstName || '',
+    lastName: profile?.lastName || '',
+    bio: profile?.bio || '',
+    skills: profile?.skills || [],
+    experience: profile?.experience || 'beginner',
+    location: profile?.location || '',
+    timezone: profile?.timezone || '',
+    availability: profile?.availability || 'flexible',
+    portfolioLinks: profile?.portfolioLinks || [],
     socialLinks: {
-      github: '',
-      linkedin: '',
-      twitter: '',
-      website: '',
+      github: profile?.socialLinks?.github || '',
+      linkedin: profile?.socialLinks?.linkedin || '',
+      twitter: profile?.socialLinks?.twitter || '',
+      website: profile?.socialLinks?.website || '',
     },
-    isProfilePublic: true,
-  });
+    isProfilePublic: profile?.isProfilePublic ?? true,
+  }));
 
   const [newSkill, setNewSkill] = useState('');
   const [newPortfolioLink, setNewPortfolioLink] = useState<PortfolioLink>({ name: '', url: '' });
   const [validationError, setValidationError] = useState('');
-
-  const typedProfile = profile as UserWithId | undefined;
-
-  useEffect(() => {
-    if (typedProfile) {
-      setFormData({
-        firstName: typedProfile.firstName || '',
-        lastName: typedProfile.lastName || '',
-        bio: typedProfile.bio || '',
-        skills: typedProfile.skills || [],
-        experience: typedProfile.experience || 'beginner',
-        location: typedProfile.location || '',
-        timezone: typedProfile.timezone || '',
-        availability: typedProfile.availability || 'flexible',
-        portfolioLinks: typedProfile.portfolioLinks || [],
-        socialLinks: {
-          github: typedProfile.socialLinks?.github || '',
-          linkedin: typedProfile.socialLinks?.linkedin || '',
-          twitter: typedProfile.socialLinks?.twitter || '',
-          website: typedProfile.socialLinks?.website || '',
-        },
-        isProfilePublic:
-          typedProfile.isProfilePublic !== undefined ? typedProfile.isProfilePublic : true,
-      });
-    }
-  }, [typedProfile]);
 
   const handleChange = (
     e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | SelectChangeEvent
@@ -178,10 +154,10 @@ const Profile: React.FC = () => {
         return;
       }
 
-      const formData = new FormData();
-      formData.append('avatar', file);
+      const avatarFormData = new FormData();
+      avatarFormData.append('avatar', file);
 
-      uploadAvatarMutation.mutate(formData, {
+      uploadAvatarMutation.mutate(avatarFormData, {
         onSuccess: (data) => {
           console.log('✅ Avatar uploaded:', data);
           setValidationError('');
@@ -246,46 +222,6 @@ const Profile: React.FC = () => {
     });
   };
 
-  // Authentication check
-  if (!isAuthenticated) {
-    return (
-      <Container maxWidth="md">
-        <Box sx={{ mt: 4 }}>
-          <Alert severity="warning" sx={{ mb: 3 }}>
-            <Typography variant="h6" gutterBottom>
-              Authentication Required
-            </Typography>
-            You must be logged in to view your profile.
-          </Alert>
-          <Button variant="contained" href="/login">
-            Go to Login
-          </Button>
-        </Box>
-      </Container>
-    );
-  }
-
-  if (profileLoading) {
-    return (
-      <Container maxWidth="md">
-        <Box
-          sx={{
-            mt: 4,
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            minHeight: '300px',
-          }}
-        >
-          <CircularProgress />
-          <Typography variant="h6" sx={{ ml: 2 }}>
-            Loading profile...
-          </Typography>
-        </Box>
-      </Container>
-    );
-  }
-
   return (
     <Container maxWidth="md">
       <Box sx={{ mt: 4, mb: 4 }}>
@@ -320,7 +256,7 @@ const Profile: React.FC = () => {
                 <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mb: 3 }}>
                   <Box sx={{ position: 'relative', mb: 2 }}>
                     <Avatar
-                      user={typedProfile}
+                      user={profile}
                       size="xxl"
                       onClick={handleAvatarClick}
                       sx={{ cursor: 'pointer' }}
@@ -364,7 +300,7 @@ const Profile: React.FC = () => {
                     >
                       {uploadAvatarMutation.isPending ? 'Uploading...' : 'Change Photo'}
                     </Button>
-                    {typedProfile?.profileImage && (
+                    {profile?.profileImage && (
                       <Button
                         variant="outlined"
                         size="small"
@@ -680,6 +616,65 @@ const Profile: React.FC = () => {
         </Paper>
       </Box>
     </Container>
+  );
+};
+
+const Profile: React.FC = () => {
+  // Auth and profile data
+  const { isAuthenticated } = useAuth();
+  const { data: profile, isLoading: profileLoading, error: profileError } = useMyProfile();
+
+  const typedProfile = profile as UserWithId | undefined;
+
+  // Authentication check
+  if (!isAuthenticated) {
+    return (
+      <Container maxWidth="md">
+        <Box sx={{ mt: 4 }}>
+          <Alert severity="warning" sx={{ mb: 3 }}>
+            <Typography variant="h6" gutterBottom>
+              Authentication Required
+            </Typography>
+            You must be logged in to view your profile.
+          </Alert>
+          <Button variant="contained" href="/login">
+            Go to Login
+          </Button>
+        </Box>
+      </Container>
+    );
+  }
+
+  if (profileLoading) {
+    return (
+      <Container maxWidth="md">
+        <Box
+          sx={{
+            mt: 4,
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            minHeight: '300px',
+          }}
+        >
+          <CircularProgress />
+          <Typography variant="h6" sx={{ ml: 2 }}>
+            Loading profile...
+          </Typography>
+        </Box>
+      </Container>
+    );
+  }
+
+  return (
+    <ProfileForm
+      profile={typedProfile}
+      profileError={profileError}
+      // Re-seed the form only when the server data actually changes (post-save or an
+      // out-of-band edit) — updatedAt changes then, but stays stable across no-op
+      // refetches, so in-progress edits aren't clobbered by background revalidation.
+      key={typedProfile?.updatedAt ?? typedProfile?._id}
+    />
   );
 };
 


### PR DESCRIPTION
Audits the frontend with the [use-effect-killer](https://github.com/victor36max/use-effect-killer) catalog (React's [You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect)) and removes **7 confirmed `useEffect` anti-patterns**. Verified green and reviewed by two independent passes (Claude multi-agent + Codex).

## Changes

| File | Anti-pattern | Fix |
|------|-------------|-----|
| `Profile.tsx` | #12 init-state-from-props | Extract `ProfileForm` child, seed via `useState` initializer, `key={updatedAt}` |
| `ProjectForm.tsx` | #12 init-state-from-props | Extract `ProjectFormFields` + `mapProjectToFormData`, `key`-reset |
| `ResetPassword.tsx` | #1 derived state | Derive `token` from `searchParams` during render |
| `EmailVerification.tsx` | #13 fetch without cleanup | Add cleanup + per-token promise-ref request dedup |
| `UserManagement.tsx` | #3 reset-on-prop-change | `key`-remount for `EditRoleDialog` instead of the effect |
| `Register.tsx`, `Login.tsx` | no-op unmount cleanups | Delete |

## Why the `key` choices matter
- **Profile** keys on `updatedAt` (not `_id`): the form re-seeds when server data actually changes (post-save / out-of-band) but a no-op background refetch no longer clobbers in-progress edits — which the old effect did.
- **EmailVerification** caches the in-flight request per token in a ref so React StrictMode's double-invoke can't consume the single-use token twice (previously flashed a false "Verification Failed").
- **UserManagement** keeps the selected user in state on close so the dialog still plays its exit animation, while `key` still resets the role per user (preserving the no-silent-demotion fix).

## Review findings, all fixed
Two review passes flagged 4 regressions in the first-cut fixes — the EmailVerification double-fetch (both reviewers), the Profile re-sync/post-save issues, and the UserManagement dialog animation. All are addressed in this branch and re-verified.

## Verification
- `tsc --noEmit` clean · `vitest` 18 passed · `vite build` succeeds · dev server boots (`GET /` → 200)
- Only legitimate effects remain (auth redirects, message-thread scroll sync, project-list fetch, verification fetch)

No behavior change intended beyond the fixes above (removed empty-then-filled form flicker; edits no longer clobbered by background refetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)